### PR TITLE
Space-filling curve traversal for GPU and CPU added

### DIFF
--- a/src-mpi/CoMD.c
+++ b/src-mpi/CoMD.c
@@ -231,7 +231,7 @@ SimFlat* initSimulation(Command cmd)
                   printf("Skin-Distance: %f\n",skinDistance);
    } else
           skinDistance = 0.0;
-   sim->boxes = initLinkCells(sim->domain, sim->pot->cutoff + skinDistance);
+   sim->boxes = initLinkCells(sim->domain, sim->pot->cutoff + skinDistance, cmd.doHilbert);
    sim->atoms = initAtoms(sim->boxes, skinDistance);
 
    // create lattice with desired temperature and displacement.

--- a/src-mpi/defines.h
+++ b/src-mpi/defines.h
@@ -6,6 +6,10 @@
 #define BOUNDARY 1
 #define INTERIOR 2
 
+#define ISPOWER2(v) ((v) && !((v) & ((v) - 1)))
+            
+#define IDX3D(x,y,z,X,Y) ((z)*((Y)*(X)) + ((y)*(X)) + (x))
+
 /// The maximum number of atoms that can be stored in a link cell.
 #define MAXATOMS 64 
 

--- a/src-mpi/gpu_redistribute.h
+++ b/src-mpi/gpu_redistribute.h
@@ -77,7 +77,7 @@ int getBoxFromTuple(LinkCellGpu boxes, int ix, int iy, int iz)
    // local link celll.
    else
    {
-      iBox = ix + boxes.gridSize.x * iy + boxes.gridSize.x * boxes.gridSize.y * iz;
+      iBox = boxes.boxIDLookUp[IDX3D(ix,iy,iz, boxes.gridSize.x, boxes.gridSize.y)];
    }
 
    return iBox;

--- a/src-mpi/gpu_types.h
+++ b/src-mpi/gpu_types.h
@@ -88,6 +88,9 @@ typedef struct LinkCellGpuSt
   real3_t localMax;
   real3_t invBoxSize;
 
+   int *boxIDLookUp; //!< 3D array storing the box IDs 
+   int3_t *boxIDLookUpReverse; //!< 1D array storing the tuple for a given box ID 
+
   int *nAtoms;		// number of atoms per cell
 } LinkCellGpu;
 

--- a/src-mpi/haloExchange.h
+++ b/src-mpi/haloExchange.h
@@ -5,7 +5,7 @@
 #define __HALO_EXCHANGE_
 
 #include "mytype.h"
-#include "cuda_runtime.h"
+#include <cuda_runtime.h>
 
 struct AtomsSt;
 struct LinkCellSt;

--- a/src-mpi/linkCells.h
+++ b/src-mpi/linkCells.h
@@ -24,10 +24,13 @@ typedef struct LinkCellSt
    real3_old boxSize;       //!< size of box in each dimension
    real3_old invBoxSize;    //!< inverse size of box in each dimension
 
+   int *boxIDLookUp; //!< 3D array storing the box IDs 
+   int3_t *boxIDLookUpReverse; //!< 1D array storing the tuple for a given box ID 
+
    int* nAtoms;         //!< total number of atoms in each box
 } LinkCell;
 
-LinkCell* initLinkCells(const struct DomainSt* domain, real_t cutoff);
+LinkCell* initLinkCells(const struct DomainSt* domain, real_t cutoff, int useHilbert);
 void destroyLinkCells(LinkCell** boxes);
 
 int getNeighborBoxes(LinkCell* boxes, int iBox, int* nbrBoxes);

--- a/src-mpi/mycommand.c
+++ b/src-mpi/mycommand.c
@@ -43,6 +43,7 @@
 /// | \--lat        | -l          | -1            | lattice parameter (Angstroms)
 /// | \--temp       | -T          | 600           | initial temperature (K)
 /// | \--delta      | -r          | 0             | initial delta (Angstroms)
+/// | \--hilbert    | -s          | 0             | use space-filling curve 
 ///
 /// Notes: 
 /// 
@@ -207,6 +208,7 @@ Command parseCommandLine(int argc, char** argv)
    cmd.temperature = 600.0;
    cmd.initialDelta = 0.0;
    cmd.relativeSkinDistance= 0.1;
+   cmd.doHilbert = 0;
 
    // gpu-specific
    memset(cmd.method, 0, 1024);
@@ -233,7 +235,8 @@ Command parseCommandLine(int argc, char** argv)
    addArg("lat",        'l', 1, 'd',  &(cmd.lat),          0,             "lattice parameter (Angstroms)");
    addArg("temp",       'T', 1, 'd',  &(cmd.temperature),  0,             "initial temperature (K)");
    addArg("delta",      'r', 1, 'd',  &(cmd.initialDelta), 0,             "initial delta (Angstroms)");
-   addArg("skinDistance",'s', 1, 'd',  &(cmd.relativeSkinDistance), 0,     "skinDistance (relative to cutoff (default: 0.1))");
+   addArg("hilbert",    'H', 0, 'd',  &(cmd.doHilbert), 0,             "space-filling curve for the traversal of cells");
+   addArg("skinDistance",'S', 1, 'd',  &(cmd.relativeSkinDistance), 0,     "skinDistance (relative to cutoff (default: 0.1))");
    addArg("method",  'm', 1, 's',  cmd.method, sizeof(cmd.method), "thread_atom, warp_atom,cta_cell,thread_atom_nl,cpu_nl");
 
    // gpu-specific
@@ -287,6 +290,7 @@ void printCmdYaml(FILE* file, Command* cmd)
            "  GPU async opt: %d\n"
            "  GPU profiling mode: %d\n"
            "  GPU method: %s\n"
+           "  Space-filling (Hilbert): %d\n"
            "\n",
            cmd->doeam,
            cmd->potDir,
@@ -302,7 +306,8 @@ void printCmdYaml(FILE* file, Command* cmd)
            cmd->initialDelta,
 	   cmd->gpuAsync,
 	   cmd->gpuProfile,
-	   cmd->method
+	   cmd->method,
+	   cmd->doHilbert
    );
    fflush(file);
 }

--- a/src-mpi/mycommand.h
+++ b/src-mpi/mycommand.h
@@ -30,6 +30,7 @@ typedef struct CommandSt
    double initialDelta; //!< magnitude of initial displacement from lattice (in Angstroms)
    double initialSkinDistance; //!< initial skinDistance in percent
    char method[1024]; //!< method to use on gpu: thread/atom, warp/atom or others
+   int doHilbert;          //!< a flag to determine whether we're using a space-filling curve for the traversal of the cells 
  
    int gpuAsync;	//!< communication latency hiding optimization using streams
    int gpuProfile;	//!< skip redistribute routines and run only one step of compute forces

--- a/src-mpi/neighborList.c
+++ b/src-mpi/neighborList.c
@@ -121,7 +121,9 @@ void buildNeighborListCpu(SimFlat* s)
                    for (int jTmp=0; jTmp<nNbrBoxes; jTmp++)
                    {
                            int jBox = nbrBoxes[jTmp];
+#ifndef FULLLIST 
                            if (jBox < iBox ) continue;
+#endif
 
                            int nJBox = s->boxes->nAtoms[jBox];
                            // loop over atoms in iBox
@@ -138,7 +140,11 @@ void buildNeighborListCpu(SimFlat* s)
                                    // loop over atoms in jBox
                                    for (int jOff=MAXATOMS*jBox,ij=0; ij<nJBox; ij++,jOff++)
                                    {
-                                           if ( (iBox==jBox) &&(ij <= ii) ) continue;
+#ifndef FULLLIST 
+                                           if ( (iBox==jBox) && (ij <= ii) ) continue;
+#else
+                                           if ( (iBox==jBox) && ij == ii ) continue;
+#endif
 
                                            real_t r2 = 0.0;
                                            real3_old dr;

--- a/src-mpi/performanceTimers.c
+++ b/src-mpi/performanceTimers.c
@@ -58,6 +58,7 @@ char* timerName[numberOfTimers] = {
    "timestep",
    "  position",
    "  velocity",
+   "  neighborList",
    "  redistribute",
    "    atomHalo",
    "  force",

--- a/src-mpi/performanceTimers.h
+++ b/src-mpi/performanceTimers.h
@@ -6,8 +6,8 @@
 #include <stdio.h>
 
 /// Timer handles
-enum TimerHandle{totalTimer, loopTimer, timestepTimer,neighborListBuildTimer,
-                 positionTimer, velocityTimer,  redistributeTimer,
+enum TimerHandle{totalTimer, loopTimer, timestepTimer,
+                 positionTimer, velocityTimer,  neighborListBuildTimer, redistributeTimer,
                  atomHaloTimer, computeForceTimer, eamHaloTimer,
                  commHaloTimer, commReduceTimer, numberOfTimers};
 


### PR DESCRIPTION
This feature improves the caching behaviour for the l2-texture cache for the EAM-Force() function from ~70% to 97% on NVIDIA k20X.

Specify the -H commandline parameter to activate the hilbert-curve
   -> This feature is only available for gridsizes which are a power of two.
      This feature can be modified to work for all gridsizes with small changes.

Further changes include:
- Command-line bugfix (same arguments have been ambiguous
- Performance counters were buggy
